### PR TITLE
`--json` option for existing commands

### DIFF
--- a/src/main/java/org/springframework/cli/command/ProjectCatalogCommands.java
+++ b/src/main/java/org/springframework/cli/command/ProjectCatalogCommands.java
@@ -76,10 +76,16 @@ public class ProjectCatalogCommands extends AbstractSpringCliCommands {
 	}
 
 	@Command(command = "list-available", description = "List available catalogs")
-	public Table catalogListAvailable() {
+	public Object catalogListAvailable(
+			@Option(description = "JSON format output", required = false, defaultValue = "false") boolean json
+	) throws JsonProcessingException {
+		Collection<CatalogRepository> catalogRepositories = getCatalogRepositories();
+		if (json) {
+			return objectMapper.writeValueAsString(catalogRepositories);
+		}
+
 		Stream<String[]> header = Stream.<String[]>of(new String[] { "Name", "Description", "URL", "Tags"});
 		List<String[]> allRows = new ArrayList<>();
-		Collection<CatalogRepository> catalogRepositories = getCatalogRepositories();
 
 		// TODO enforce all entries have name and Url
 		Stream<String[]> fromCatalogRows;
@@ -103,11 +109,6 @@ public class ProjectCatalogCommands extends AbstractSpringCliCommands {
 		return tableBuilder.addFullBorder(BorderStyle.fancy_light).build();
 	}
 
-	@Command(command = "list-available-json", description = "List available catalogs")
-	public String catalogListAvailableJson() throws JsonProcessingException {
-		return objectMapper.writeValueAsString(getCatalogRepositories());
-	}
-
 	private Collection<CatalogRepository> getCatalogRepositories() {
 		Path path = sourceRepositoryService.retrieveRepositoryContents("https://github.com/rd-1-2022/available-catalog-repositories");
 		YamlConfigFile yamlConfigFile = new YamlConfigFile();
@@ -126,9 +127,14 @@ public class ProjectCatalogCommands extends AbstractSpringCliCommands {
 
 
 	@Command(command = "list", description = "List installed catalogs")
-	public Table catalogList() {
-		Stream<String[]> header = Stream.<String[]>of(new String[] { "Name", "Description" , "URL", "Tags" });
+	public Object catalogList(
+			@Option(description = "JSON format output", required = false, defaultValue = "false") boolean json
+	) throws JsonProcessingException {
 		Collection<ProjectCatalog> projectCatalogs = springCliUserConfig.getProjectCatalogs().getProjectCatalogs();
+		if (json) {
+			return objectMapper.writeValueAsString(projectCatalogs);
+		}
+		Stream<String[]> header = Stream.<String[]>of(new String[] { "Name", "Description" , "URL", "Tags" });
 		Stream<String[]> rows = null;
 		if (projectCatalogs != null) {
 			rows = projectCatalogs.stream()
@@ -147,12 +153,6 @@ public class ProjectCatalogCommands extends AbstractSpringCliCommands {
 		TableBuilder tableBuilder = new TableBuilder(model);
 		return tableBuilder.addFullBorder(BorderStyle.fancy_light).build();
 	}
-
-	@Command(command = "list-json", description = "List installed catalogs")
-	public String catalogListJson() throws JsonProcessingException {
-		return objectMapper.writeValueAsString(springCliUserConfig.getProjectCatalogs().getProjectCatalogs());
-	}
-
 
 	@Command(command = "add", description = "Add a project to a project catalog")
 	public void catalogAdd(

--- a/src/main/java/org/springframework/cli/command/ProjectCatalogCommands.java
+++ b/src/main/java/org/springframework/cli/command/ProjectCatalogCommands.java
@@ -26,6 +26,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,14 +62,17 @@ public class ProjectCatalogCommands extends AbstractSpringCliCommands {
 	private final SourceRepositoryService sourceRepositoryService;
 
 	private final TerminalMessage terminalMessage;
+	private final ObjectMapper objectMapper;
 
 
 	@Autowired
 	public ProjectCatalogCommands(SpringCliUserConfig springCliUserConfig,
-			SourceRepositoryService sourceRepositoryService, TerminalMessage terminalMessage) {
+								  SourceRepositoryService sourceRepositoryService, TerminalMessage terminalMessage,
+								  ObjectMapper objectMapper) {
 		this.springCliUserConfig = springCliUserConfig;
 		this.sourceRepositoryService = sourceRepositoryService;
 		this.terminalMessage = terminalMessage;
+		this.objectMapper = objectMapper;
 	}
 
 	@Command(command = "list-available", description = "List available catalogs")
@@ -96,6 +101,11 @@ public class ProjectCatalogCommands extends AbstractSpringCliCommands {
 		TableModel model = new ArrayTableModel(data);
 		TableBuilder tableBuilder = new TableBuilder(model);
 		return tableBuilder.addFullBorder(BorderStyle.fancy_light).build();
+	}
+
+	@Command(command = "list-available-json", description = "List available catalogs")
+	public String catalogListAvailableJson() throws JsonProcessingException {
+		return objectMapper.writeValueAsString(getCatalogRepositories());
 	}
 
 	private Collection<CatalogRepository> getCatalogRepositories() {
@@ -137,6 +147,12 @@ public class ProjectCatalogCommands extends AbstractSpringCliCommands {
 		TableBuilder tableBuilder = new TableBuilder(model);
 		return tableBuilder.addFullBorder(BorderStyle.fancy_light).build();
 	}
+
+	@Command(command = "list-json", description = "List installed catalogs")
+	public String catalogListJson() throws JsonProcessingException {
+		return objectMapper.writeValueAsString(springCliUserConfig.getProjectCatalogs().getProjectCatalogs());
+	}
+
 
 	@Command(command = "add", description = "Add a project to a project catalog")
 	public void catalogAdd(

--- a/src/main/java/org/springframework/cli/command/ProjectCommands.java
+++ b/src/main/java/org/springframework/cli/command/ProjectCommands.java
@@ -122,7 +122,7 @@ public class ProjectCommands {
 			.map(tr -> new String[] { tr.name(),
 					Objects.requireNonNullElse(tr.description, ""),
 					tr.url(),
-					tr.catalog,
+					Objects.requireNonNullElse(tr.catalog, ""),
 					(Objects.requireNonNullElse(tr.tags(), "")).toString() }
 		);
 

--- a/src/main/java/org/springframework/cli/command/ProjectCommands.java
+++ b/src/main/java/org/springframework/cli/command/ProjectCommands.java
@@ -122,7 +122,7 @@ public class ProjectCommands {
 			.map(tr -> new String[] { tr.name(),
 					Objects.requireNonNullElse(tr.description, ""),
 					tr.url(),
-					"",
+					tr.catalog,
 					(Objects.requireNonNullElse(tr.tags(), "")).toString() }
 		);
 

--- a/src/test/java/org/springframework/cli/command/ProjectCatalogCommandsTests.java
+++ b/src/test/java/org/springframework/cli/command/ProjectCatalogCommandsTests.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.jimfs.Jimfs;
 import org.junit.jupiter.api.Test;
@@ -62,7 +63,7 @@ public class ProjectCatalogCommandsTests {
 			tags.add("spring");
 			tags.add("guide");
 			projectCatalogCommands.catalogAdd("getting-started", "https://github.com/rd-1-2022/spring-gs-catalog/", "Spring Getting Started Projects", tags);
-			table = projectCatalogCommands.catalogList();
+			table = (Table) projectCatalogCommands.catalogList(false);
 			System.out.println(table.render(100));
 			verifyTableValue(table, 1, 0, "getting-started");
 			verifyTableValue(table, 1, 1, "Spring Getting Started Projects");
@@ -81,8 +82,8 @@ public class ProjectCatalogCommandsTests {
 		});
 	}
 
-	private static void verifyEmptyCatalog(ProjectCatalogCommands projectCatalogCommands) {
-		Table table = projectCatalogCommands.catalogList();
+	private static void verifyEmptyCatalog(ProjectCatalogCommands projectCatalogCommands) throws JsonProcessingException {
+		Table table = (Table) projectCatalogCommands.catalogList(false);
 		System.out.println(table.render(100));
 		assertThat(table.getModel().getColumnCount()).isEqualTo(4);
 		assertThat(table.getModel().getRowCount()).isEqualTo(1);

--- a/src/test/java/org/springframework/cli/command/ProjectCatalogCommandsTests.java
+++ b/src/test/java/org/springframework/cli/command/ProjectCatalogCommandsTests.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.jimfs.Jimfs;
 import org.junit.jupiter.api.Test;
 
@@ -112,9 +113,14 @@ public class ProjectCatalogCommandsTests {
 		}
 
 		@Bean
+		ObjectMapper objectMapper() {
+			return new ObjectMapper();
+		}
+
+		@Bean
 		ProjectCatalogCommands projectCatalogCommands(SpringCliUserConfig springCliUserConfig,
-				SourceRepositoryService sourceRepositoryService) {
-			ProjectCatalogCommands projectCatalogCommands = new ProjectCatalogCommands(springCliUserConfig, sourceRepositoryService, TerminalMessage.noop());
+													  SourceRepositoryService sourceRepositoryService, ObjectMapper objectMapper) {
+			ProjectCatalogCommands projectCatalogCommands = new ProjectCatalogCommands(springCliUserConfig, sourceRepositoryService, TerminalMessage.noop(), objectMapper);
 			return projectCatalogCommands;
 		}
 	}

--- a/src/test/java/org/springframework/cli/command/ProjectCatalogInitializerTests.java
+++ b/src/test/java/org/springframework/cli/command/ProjectCatalogInitializerTests.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.jimfs.Jimfs;
 import org.junit.jupiter.api.Test;
 
@@ -102,9 +103,14 @@ public class ProjectCatalogInitializerTests {
 		}
 
 		@Bean
+		ObjectMapper objectMapper() {
+			return new ObjectMapper();
+		}
+
+		@Bean
 		ProjectCatalogCommands projectCatalogCommands(SpringCliUserConfig springCliUserConfig,
-				SourceRepositoryService sourceRepositoryService) {
-			return new ProjectCatalogCommands(springCliUserConfig, sourceRepositoryService, TerminalMessage.noop());
+				SourceRepositoryService sourceRepositoryService, ObjectMapper objectMapper) {
+			return new ProjectCatalogCommands(springCliUserConfig, sourceRepositoryService, TerminalMessage.noop(), objectMapper);
 		}
 
 		@Bean
@@ -148,8 +154,13 @@ public class ProjectCatalogInitializerTests {
 		}
 
 		@Bean
+		ObjectMapper objectMapper() {
+			return new ObjectMapper();
+		}
+
+		@Bean
 		ProjectCatalogCommands projectCatalogCommands(SpringCliUserConfig springCliUserConfig,
-				SourceRepositoryService sourceRepositoryService) {
+				SourceRepositoryService sourceRepositoryService, ObjectMapper objectMapper) {
 			List<ProjectCatalog> projectCatalogList = new ArrayList<ProjectCatalog>();
 			projectCatalogList.add(ProjectCatalog.of("fooname", "foodescription", "foourl", Arrays.asList("footag1, footag2")));
 
@@ -158,7 +169,7 @@ public class ProjectCatalogInitializerTests {
 			projectCatalogs.setProjectCatalogs(projectCatalogList);
 			springCliUserConfig.setProjectCatalogs(projectCatalogs);
 
-			return new ProjectCatalogCommands(springCliUserConfig, sourceRepositoryService, TerminalMessage.noop());
+			return new ProjectCatalogCommands(springCliUserConfig, sourceRepositoryService, TerminalMessage.noop(), objectMapper);
 		}
 
 		@Bean

--- a/src/test/java/org/springframework/cli/command/ProjectCatalogInitializerTests.java
+++ b/src/test/java/org/springframework/cli/command/ProjectCatalogInitializerTests.java
@@ -55,7 +55,7 @@ public class ProjectCatalogInitializerTests {
 		contextRunner.run((context) -> {
 			assertThat(context).hasSingleBean(ProjectCatalogCommands.class);
 			ProjectCatalogCommands projectCatalogCommands = context.getBean(ProjectCatalogCommands.class);
-			Table table = projectCatalogCommands.catalogList();
+			Table table = (Table) projectCatalogCommands.catalogList(false);
 			assertThat(table.getModel().getRowCount()).isEqualTo(2);
 			verifyTableValue(table, 1, 0, "gs");
 			verifyTableValue(table, 1, 1, "Getting Started Catalog");
@@ -77,7 +77,7 @@ public class ProjectCatalogInitializerTests {
 		contextRunner.run((context) -> {
 			assertThat(context).hasSingleBean(ProjectCatalogCommands.class);
 			ProjectCatalogCommands projectCatalogCommands = context.getBean(ProjectCatalogCommands.class);
-			Table table = projectCatalogCommands.catalogList();
+			Table table = (Table) projectCatalogCommands.catalogList(false);
 			assertThat(table.getModel().getRowCount()).isEqualTo(2);
 			verifyTableValue(table, 1, 0, "myname");
 			verifyTableValue(table, 1, 1, "mydescription");
@@ -126,7 +126,7 @@ public class ProjectCatalogInitializerTests {
 		contextRunner.run((context) -> {
 			assertThat(context).hasSingleBean(ProjectCatalogCommands.class);
 			ProjectCatalogCommands projectCatalogCommands = context.getBean(ProjectCatalogCommands.class);
-			Table table = projectCatalogCommands.catalogList();
+			Table table = (Table) projectCatalogCommands.catalogList(false);
 			assertThat(table.getModel().getRowCount()).isEqualTo(2);
 			verifyTableValue(table, 1, 0, "fooname");
 			verifyTableValue(table, 1, 1, "foodescription");

--- a/src/test/java/org/springframework/cli/command/ProjectCommandsTests.java
+++ b/src/test/java/org/springframework/cli/command/ProjectCommandsTests.java
@@ -50,7 +50,7 @@ public class ProjectCommandsTests {
 			ProjectCommands projectCommands = context.getBean(ProjectCommands.class);
 
 			// Get empty table, assert header values
-			Table table = projectCommands.projectList();
+			Table table = (Table) projectCommands.projectList(false);
 			System.out.println("should be empty table");
 			System.out.println(table.render(100));
 			assertEmptyProjectListTable(table);
@@ -60,7 +60,7 @@ public class ProjectCommandsTests {
 			tags.add("data");
 			tags.add("jpa");
 			projectCommands.projectAdd("jpa", "https://github.com/rd-1-2022/rpt-spring-data-jpa", "Learn JPA", tags);
-			table = projectCommands.projectList();
+			table = (Table) projectCommands.projectList(false);
 			System.out.println("SHould have 1 entry");
 			System.out.println(table.render(100));
 			verifyTableValue(table, 1, 0, "jpa");
@@ -72,7 +72,7 @@ public class ProjectCommandsTests {
 
 			// Remove project
 			projectCommands.projectRemove("jpa");
-			table = projectCommands.projectList();
+			table = (Table) projectCommands.projectList(false);
 			System.out.println("Should be empty table");
 			System.out.println(table.render(100));
 			assertThat(table.getModel().getColumnCount()).isEqualTo(5);

--- a/src/test/java/org/springframework/cli/command/ProjectCommandsTests.java
+++ b/src/test/java/org/springframework/cli/command/ProjectCommandsTests.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.jimfs.Jimfs;
 import org.junit.jupiter.api.Test;
 
@@ -105,9 +106,14 @@ public class ProjectCommandsTests {
 		}
 
 		@Bean
+		ObjectMapper objectMapper() {
+			return new ObjectMapper();
+		}
+
+		@Bean
 		ProjectCommands projectCommands(SpringCliUserConfig springCliUserConfig,
-				SourceRepositoryService sourceRepositoryService) {
-			ProjectCommands projectCommands = new ProjectCommands(springCliUserConfig, sourceRepositoryService, TerminalMessage.noop());
+										SourceRepositoryService sourceRepositoryService, ObjectMapper objectMapper) {
+			ProjectCommands projectCommands = new ProjectCommands(springCliUserConfig, sourceRepositoryService, TerminalMessage.noop(), objectMapper);
 			return projectCommands;
 		}
 	}


### PR DESCRIPTION
Turns out that by returning an `Object` rather than `Table` or `String` command handler can support the `--json` option
Might fix #147 and replaces #148