### PR TITLE
Set fixed snapshot version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ ext {
 	set('kohsukeVersion', '1.301')
 	set('gitlab4jVersion', '4.19.0')
 	set('openrewriteVersion', '8.13.4')
-	set('springRewriteCommonsVersion', '0.1.0-SNAPSHOT')
+	set('springRewriteCommonsStarterBootUpgradeVersion', '0.1.0-20240126.085448-4')
 	set('antVersion', '1.10.9')
 	set('mavenModelVersion', '3.5.4')
 	set('tikaVersion', '1.18')
@@ -88,7 +88,7 @@ dependencyManagement {
 		dependency "org.rauschig:jarchivelib:${jarchivelibVersion}"
 		dependency "org.kohsuke:github-api:${kohsukeVersion}"
 		dependency "org.gitlab4j:gitlab4j-api:${gitlab4jVersion}"
-		dependency "org.springframework.rewrite:spring-rewrite-commons-starter-boot-upgrade:${springRewriteCommonsVersion}"
+		dependency "org.springframework.rewrite:spring-rewrite-commons-starter-boot-upgrade:${springRewriteCommonsStarterBootUpgradeVersion}"
 		dependency "org.openrewrite:rewrite-test:${openrewriteVersion}"
 		dependency "org.openrewrite:rewrite-java-17:${openrewriteVersion}"
 		dependency "org.openrewrite:rewrite-xml:${openrewriteVersion}"


### PR DESCRIPTION
`spring-rewrite-commons` had breaking API changes and the next snapshot version will break `spring-cli`.
I plan to do another snapshot release after this PR has been merged and update spring-cli using the recipe(s) [here](https://github.com/fabapp2/spring-rewrite-commons-recipes).
