### PR TITLE
RewriteRecipeLauncher was moved

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,8 @@ dependencies {
 	implementation 'com.theokanning.openai-gpt3-java:service'
 	implementation 'org.commonmark:commonmark'
 	implementation 'org.springframework.rewrite:spring-rewrite-commons-starter-boot-upgrade'
+	implementation 'org.springframework.rewrite:spring-rewrite-commons-launcher'
+
 	testImplementation 'org.openrewrite:rewrite-test'
 	testImplementation 'uk.org.webcompere:system-stubs-jupiter'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/org/springframework/cli/command/BootCommands.java
+++ b/src/main/java/org/springframework/cli/command/BootCommands.java
@@ -21,9 +21,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cli.config.SpringCliUserConfig;
 import org.springframework.cli.git.SourceRepositoryService;
 import org.springframework.cli.merger.ProjectHandler;
-import org.springframework.rewrite.execution.RewriteRecipeLauncher;
+
 import org.springframework.cli.util.ProjectInfo;
 import org.springframework.cli.util.TerminalMessage;
+import org.springframework.rewrite.RewriteRecipeLauncher;
 import org.springframework.shell.command.annotation.Command;
 import org.springframework.shell.command.annotation.Option;
 
@@ -39,7 +40,8 @@ public class BootCommands extends AbstractSpringCliCommands {
 	@Autowired
 	public BootCommands(SpringCliUserConfig springCliUserConfig,
                         SourceRepositoryService sourceRepositoryService,
-                        TerminalMessage terminalMessage, RewriteRecipeLauncher rewriteRecipeLauncher) {
+                        TerminalMessage terminalMessage,
+						RewriteRecipeLauncher rewriteRecipeLauncher) {
 		this.springCliUserConfig = springCliUserConfig;
 		this.sourceRepositoryService = sourceRepositoryService;
 		this.terminalMessage = terminalMessage;

--- a/src/test/java/org/springframework/cli/command/BootCommandsTest.java
+++ b/src/test/java/org/springframework/cli/command/BootCommandsTest.java
@@ -9,7 +9,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.cli.config.SpringCliUserConfig;
 import org.springframework.cli.git.SourceRepositoryService;
 import org.springframework.cli.util.TerminalMessage;
-import org.springframework.rewrite.execution.RewriteRecipeLauncher;
+import org.springframework.rewrite.RewriteRecipeLauncher;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/org/springframework/cli/support/MockConfigurations.java
+++ b/src/test/java/org/springframework/cli/support/MockConfigurations.java
@@ -39,7 +39,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.rewrite.boot.autoconfigure.RewriteLauncherConfiguration;
-import org.springframework.rewrite.execution.RewriteRecipeLauncher;
+import org.springframework.rewrite.RewriteRecipeLauncher;
 import org.springframework.shell.style.ThemeResolver;
 
 import java.nio.file.FileSystem;


### PR DESCRIPTION
It seems RewriteRecipeLauncher was moved:
https://github.com/spring-projects/spring-rewrite-commons/commit/861eabc7002b44ddc7f0b0cdbc3003dd814ec818

<img width="1277" alt="Screenshot 2024-01-29 at 2 17 23 pm" src="https://github.com/spring-projects/spring-cli/assets/5586453/69f1c24e-e128-4485-b9e3-9e7861fcf747">

This should correct the package.