### PR TITLE
Fix Typos in Documentation

### DIFF
--- a/docs/modules/ROOT/pages/action-guide.adoc
+++ b/docs/modules/ROOT/pages/action-guide.adoc
@@ -28,7 +28,7 @@ actions:
       text: Hello {{user-name}} on {{os-name}}.
 ```
 
-The `{{user-name}}` and `{{os-name}} variables are replaced with actual values by the Handlebars template engine.
+The `{{user-name}}` and `{{os-name}}` variables are replaced with actual values by the Handlebars template engine.
 Command line options passed to user-defined command are exposed as variables to be used by the template engine.
 
 For more information on predefined template engine variables, see the xref:user-command-guide.adoc#_template_engine[Template Engine] section.

--- a/docs/modules/ROOT/pages/action-guide.adoc
+++ b/docs/modules/ROOT/pages/action-guide.adoc
@@ -135,6 +135,7 @@ actions:
 
 For more information on predefined template engine variables, see the xref:user-command-guide.adoc#_template_engine[Template Engine] section.
 
+[[action-inject]]
 == Inject
 
 The `inject` action is used to inject text into a file.

--- a/docs/modules/ROOT/pages/adding-to-existing-projects.adoc
+++ b/docs/modules/ROOT/pages/adding-to-existing-projects.adoc
@@ -8,7 +8,7 @@ You can use two methods to add code to existing projects:
 [[adding-using-boot-add-command]]
 == Using the Boot Add Command
 
-The `boot add`` command allows for intelligent merging of an existing project into the current project.
+The `boot add` command allows for intelligent merging of an existing project into the current project.
 The code of the existing project, located in a source code repository, is checked out into a temporary directory.
 The package structure of the existing project is then refactored to match the current project.
 Finally, all code and configuration are copied from the temporary location, creating new files or updating existing ones as necessary.

--- a/docs/modules/ROOT/pages/ai-guide.adoc
+++ b/docs/modules/ROOT/pages/ai-guide.adoc
@@ -62,7 +62,7 @@ To do so, provide a brief description of the code you want to add by using the `
 
 By default, this command modifies your code base.
 
-The following listing showss an example:
+The following listing shows an example:
 
 [source, bash]
 ----

--- a/docs/modules/ROOT/pages/roles-guide.adoc
+++ b/docs/modules/ROOT/pages/roles-guide.adoc
@@ -128,7 +128,7 @@ Hello Mondo on Linux.  Italian
 
 The value of `{{greeting}}` comes from the role variable because it was not provided as a command-line option.
 
-The `{{language}}` variable was not a command line option, but it is is available to use with Handlebars expressions.
+The `{{language}}` variable was not a command line option, but it is available to use with Handlebars expressions.
 
 Now we can remove the generated file. in the interactive shell, we run `. ! rm hello.txt` and pass in the `greeting` command line option:
 


### PR DESCRIPTION
I have corrected some typos, and I would appreciate it if you could check them.