### PR TITLE
Fix typo in ListLineTracker

### DIFF
--- a/src/main/java/org/springframework/cli/runtime/engine/actions/handlers/json/ListLineTracker.java
+++ b/src/main/java/org/springframework/cli/runtime/engine/actions/handlers/json/ListLineTracker.java
@@ -93,8 +93,8 @@ class ListLineTracker {
 				}
 			}
 			else if (offset == line.offset) {
-				// left = right = mid;
-				left = mid;
+				right = mid;
+				left = right;
 			}
 		}
 


### PR DESCRIPTION
Looks like the typo appeared due to quickly get around a formatter issue but then was never really dealt with.
It is important to get it fixed for the release to have `guide apply --lsp-edit` working properly