### PR TITLE
Upgrade spring-shell 3.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '3.2.5'
+	id 'org.springframework.boot' version '3.3.0'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
 	id 'org.graalvm.buildtools.native' version '0.9.19' apply false
@@ -42,7 +42,7 @@ repositories {
 }
 
 ext {
-	set('springShellVersion', '3.2.4')
+	set('springShellVersion', '3.3.0')
 	set('initializrVersion', '0.11.1')
 	set('jarchivelibVersion', '1.2.0')
 	set('kohsukeVersion', '1.301')

--- a/src/main/resources/springcliapp.yml
+++ b/src/main/resources/springcliapp.yml
@@ -3,6 +3,8 @@ spring:
     web-application-type: none
     banner-mode: off
   shell:
+    interactive:
+      enabled: true
     config:
       location: "{userconfig}/springcli"
     history:


### PR DESCRIPTION
- Enable interactive runner as shell 3.3.x only have non-interactive runner enabled by default
- Needs Upgrade to spring-boot 3.3.0
- Fixes #201
- Fixes #202