### PR TITLE
Use junit tags with tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,34 +139,26 @@ dependencyManagement {
 }
 
 test {
-	useJUnitPlatform()
-}
-
-sourceSets {
-	integrationTest {
-		java {
-			compileClasspath += main.output + test.output
-			runtimeClasspath += main.output + test.output
-			srcDir file('src/integrationTest/java')
+	useJUnitPlatform {
+		if (!project.hasProperty('cliIncludeTags') && !project.hasProperty('cliExcludeTags')) {
+			includeTags = ['none()']
 		}
-		resources.srcDir file('src/integrationTest/resources')
+		else {
+			if (project.hasProperty('cliIncludeTags') && cliIncludeTags.size() > 0) {
+				includeTags = cliIncludeTags.split(',')
+			}
+			if (project.hasProperty('cliExcludeTags') && cliExcludeTags.size() > 0) {
+				excludeTags = cliExcludeTags.split(',')
+			}
+		}
+
 	}
-}
-
-task integrationTest(type: Test) {
-	useJUnitPlatform()
-	testClassesDirs = sourceSets.integrationTest.output.classesDirs
-	classpath = sourceSets.integrationTest.runtimeClasspath
-}
-
-configurations {
-	integrationTestCompile.extendsFrom testCompile
-	integrationTestRuntime.extendsFrom testRuntime
-	integrationTestImplementation.extendsFrom testImplementation
-}
-
-rootProject.tasks.named("processIntegrationTestResources") {
-	duplicatesStrategy = 'include'
+	if (project.hasProperty('cliTestLogging') && (cliTestLogging.isEmpty() ? true : cliTestLogging.toBoolean())) {
+		testLogging {
+			showStandardStreams = true
+			events = ["standardOut", "started", "passed", "failed", "skipped"]
+		}
+	}
 }
 
 task generateGitProperties {

--- a/src/test/java/org/springframework/cli/CliTags.java
+++ b/src/test/java/org/springframework/cli/CliTags.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cli;
+
+/**
+ * JUnit tags used in tests.
+ */
+public final class CliTags {
+
+	private CliTags() {
+	}
+
+	public static final String IT = "it";
+
+	public static final String SMOKE = "smoke";
+
+	public static final String AI = "ai";
+
+	public static final String GITHUB = "github";
+
+	public static final String GITLAB = "gitlab";
+
+}

--- a/src/test/java/org/springframework/cli/git/GitSourceRepositoryServiceTests.java
+++ b/src/test/java/org/springframework/cli/git/GitSourceRepositoryServiceTests.java
@@ -21,9 +21,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.apache.commons.io.file.PathUtils;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import org.springframework.cli.CliTags;
 import org.springframework.cli.config.SpringCliUserConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,6 +37,7 @@ public class GitSourceRepositoryServiceTests {
 	 * @param tempDir location to put contents of git repository
 	 */
 	@Test
+	@Tag(CliTags.GITHUB)
 	void testRetrieval(@TempDir Path tempDir) throws IOException {
 		GitSourceRepositoryService urlRepositoryService = new GitSourceRepositoryService(new SpringCliUserConfig());
 		Path contentPath = urlRepositoryService.retrieveRepositoryContents("https://github.com/rd-1-2022/rest-service");

--- a/src/test/java/org/springframework/cli/merger/ai/ProjectNameHeuristicAiServiceTests.java
+++ b/src/test/java/org/springframework/cli/merger/ai/ProjectNameHeuristicAiServiceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
 
 package org.springframework.cli.merger.ai;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.cli.CliTags;
 import org.springframework.cli.merger.ai.service.ProjectNameHeuristicAiService;
 import org.springframework.cli.util.TerminalMessage;
 
@@ -26,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ProjectNameHeuristicAiServiceTests {
 
 	@Test
+	@Tag(CliTags.AI)
 	void deriveProjectName() {
 		ProjectNameHeuristicAiService projectNameHeuristic = new ProjectNameHeuristicAiService(TerminalMessage.noop());
 


### PR DESCRIPTION
- Remove "integrationTests" from build in favour of tagging tests
- Only untagged tests are run by default, thought we can can modify default includeTags = ['none()'] if there's need to run some tags on default
- Use -PcliIncludeTags=exp1,exp2 and/or -PcliExcludeTags=exp1,exp2 to manually define what tags to use
- Also -PcliTestLogging which takes boolean and defaults to true if defined as it enables more verbose test logging
- Added CliTags which should always have valid and expected tags having some defaults like; it, smoke, ai, github and gitlab
- Fixes #197